### PR TITLE
debug: 롤 새 패치버전에 대한 챔피언 조합승률 데이터 분석량이 저조한 경우에 대한 예외처리

### DIFF
--- a/src/combination-stat/combination-stat.repository.ts
+++ b/src/combination-stat/combination-stat.repository.ts
@@ -11,8 +11,8 @@ export class CombinationStatRepository {
     private readonly combinationStatRepository: Repository<CombinationStatEntity>,
   ) {}
 
-  async getLatestVersion(): Promise<{ version: string }[]> {
-    return await this.combinationStatRepository.createQueryBuilder('COMBINATION_STAT').select('DISTINCT COMBINATION_STAT.version').where('COMBINATION_STAT.version != :version', { version: 'old' }).orderBy('COMBINATION_STAT.version', 'DESC').getRawMany();
+  async getVersions(): Promise<{ version: string }[]> {
+    return await this.combinationStatRepository.createQueryBuilder('COMBINATION_STAT').select(['DISTINCT COMBINATION_STAT.version']).getRawMany();
   }
   //   mainPage 티어리스트
   async getTierList(category, version): Promise<CombinationStatCommonDto[]> {

--- a/src/combination-stat/test/combination-stat.service.spec.ts
+++ b/src/combination-stat/test/combination-stat.service.spec.ts
@@ -29,7 +29,7 @@ describe('CombinationStatController', () => {
   });
 
   it('request로 받은 category에 대응해 TierList를 response 하는가?', async () => {
-    jest.spyOn(repository, 'getLatestVersion').mockImplementation(
+    jest.spyOn(repository, 'getVersions').mockImplementation(
       () =>
         new Promise((resolve) => {
           resolve([{ version: 'example' }]);
@@ -53,7 +53,7 @@ describe('CombinationStatController', () => {
   });
 
   it('individualChamp 테스트: 데이터가 없는 경우에 에러 메시지를 잘 응답하는가?', async () => {
-    jest.spyOn(repository, 'getLatestVersion').mockImplementation(
+    jest.spyOn(repository, 'getVersions').mockImplementation(
       () =>
         new Promise((resolve) => {
           resolve([{ version: 'example' }]);
@@ -73,7 +73,7 @@ describe('CombinationStatController', () => {
   });
 
   it('individualChamp 테스트: 포지션이 정글/서폿이 아닌 경우, mainChampId <-> subChampId 변경X', async () => {
-    jest.spyOn(repository, 'getLatestVersion').mockImplementation(
+    jest.spyOn(repository, 'getVersions').mockImplementation(
       () =>
         new Promise((resolve) => {
           resolve([{ version: 'example' }]);
@@ -99,7 +99,7 @@ describe('CombinationStatController', () => {
   });
 
   it('individualChamp 테스트: 포지션이 서폿인 경우, mainChampId <-> subChampId 변경', async () => {
-    jest.spyOn(repository, 'getLatestVersion').mockImplementation(
+    jest.spyOn(repository, 'getVersions').mockImplementation(
       () =>
         new Promise((resolve) => {
           resolve([{ version: 'example' }]);
@@ -119,7 +119,7 @@ describe('CombinationStatController', () => {
   });
 
   it('individualChamp 테스트: 포지션이 정글인 경우, mainChampId <-> subChampId 변경', async () => {
-    jest.spyOn(repository, 'getLatestVersion').mockImplementation(
+    jest.spyOn(repository, 'getVersions').mockImplementation(
       () =>
         new Promise((resolve) => {
           resolve([{ version: 'example' }]);


### PR DESCRIPTION
- 데이터 분석량 저조에 따라 티어리스트의 length가 30 미만인 경우, 이전 패치버전의 티어리스트를 제공하도록 예외처리